### PR TITLE
Add no_std support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
-
+script:
+  - cargo test --verbose
+  - cargo test --verbose --features std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ description = "Implementation of serial protocol for Winsen MH-Z19 / MH-Z19B / M
 keywords=["mhz19", "mh-z19", "mh_z19"]
 
 [dependencies]
+
+[features]
+default = []
+std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/zenria/mh-z19-rs"
 description = "Implementation of serial protocol for Winsen MH-Z19 / MH-Z19B / MH-Z14 CO2 sensors"
 keywords=["mhz19", "mh-z19", "mh_z19"]
+categories = ["embedded", "hardware-support", "no-std"]
 
 [dependencies]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,6 @@ mod test {
     static READ_GAS_CONCENTRATION_COMMAND_ON_DEV1_PACKET: &'static [u8] =
         &[0xFF, 0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00, 0x79];
 
-
     #[test]
     fn test_checksum() {
         assert_eq!(0x79, checksum(&[0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00]));
@@ -218,6 +217,18 @@ mod test {
 
     #[test]
     fn test_get_payload() {
+        assert_eq!(
+            Err(MHZ19Error::WrongPacketLength(0)),
+            parse_payload(&[])
+        );
+        assert_eq!(
+            Err(MHZ19Error::WrongPacketLength(1)),
+            parse_payload(&[12])
+        );
+        assert_eq!(
+            Err(MHZ19Error::WrongPacketLength(12)),
+            parse_payload(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        );
         assert_eq!(
             Err(MHZ19Error::WrongStartByte(10)),
             parse_payload(&[10, 2, 3, 4, 5, 6, 7, 8, 9])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub fn parse_payload(packet: &[u8]) -> Result<&[u8], MHZ19Error> {
 /// Get the CO2 gas concentration in ppm from a response packet.
 ///
 /// Will return an error if the packet is not a "read gas concentration packet"
-pub fn parse_gas_contentration_ppm(packet: &Packet) -> Result<u32, MHZ19Error> {
+pub fn parse_gas_contentration_ppm(packet: &[u8]) -> Result<u32, MHZ19Error> {
     let payload = parse_payload(packet)?;
     if payload[0] != Command::ReadGasConcentration.get_command_value() {
         Err(MHZ19Error::WrongPacketType(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,12 @@
 //! - functions for parsing response read from the uart
 //! - functions to create command payload to send to the sensor though the uart.
 //!
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+use core::fmt;
+#[cfg(feature = "std")]
 use std::fmt;
 
 /// MH-Z12 Commands
@@ -41,16 +47,12 @@ impl Command {
     }
 }
 
-/// The command payload used to query the co2 cas concentration from the device number 1 (the default device
-/// number)
-///
-/// It is the same value as the result of get_command_packet(Command::ReadGasConcentration, 1).
-pub static READ_GAS_CONCENTRATION_COMMAND_ON_DEV1_PACKET: &'static [u8] =
-    &[0xFF, 0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00, 0x79];
+/// Both input and output packets have 10 byte length
+pub type Packet = [u8; 9];
 
 /// Get the command packet with proper header and checksum.
-fn get_command_with_bytes34(command: Command, device_number: u8, byte3: u8, byte4: u8) -> Vec<u8> {
-    let mut ret = vec![
+fn get_command_with_bytes34(command: Command, device_number: u8, byte3: u8, byte4: u8) -> Packet {
+    let mut ret: Packet = [
         0xFF,
         device_number,
         command.get_command_value(),
@@ -59,18 +61,19 @@ fn get_command_with_bytes34(command: Command, device_number: u8, byte3: u8, byte
         0x00,
         0x00,
         0x00,
+        0x00,
     ];
-    ret.push(checksum(&ret[1..]));
+    ret[8] = checksum(&ret[1..8]);
     ret
 }
 
 /// Create a command to read the gas concentration of the sensor.
-pub fn read_gas_concentration(device_number: u8) -> Vec<u8> {
+pub fn read_gas_concentration(device_number: u8) -> Packet {
     get_command_with_bytes34(Command::ReadGasConcentration, device_number, 0x00, 0x00)
 }
 
 /// Create a command to enable or disable Automatic Baseline Correction (ABC)
-pub fn set_automatic_baseline_correction(device_number: u8, enabled: bool) -> Vec<u8> {
+pub fn set_automatic_baseline_correction(device_number: u8, enabled: bool) -> Packet {
     get_command_with_bytes34(
         Command::SetAutomaticBaselineCorrection,
         device_number,
@@ -85,7 +88,7 @@ pub fn set_automatic_baseline_correction(device_number: u8, enabled: bool) -> Ve
 /// Please make sure the sensor worked under a certain level co2 for over 20 minutes.
 ///
 /// Suggest using 2000ppm as span, at least 1000ppm"
-pub fn calibrate_span_point(device_number: u8, value: u16) -> Vec<u8> {
+pub fn calibrate_span_point(device_number: u8, value: u16) -> Packet {
     get_command_with_bytes34(
         Command::CalibrateSpan,
         device_number,
@@ -97,7 +100,7 @@ pub fn calibrate_span_point(device_number: u8, value: u16) -> Vec<u8> {
 /// Create a command to set the sensor detection range (MH-Z19B only).
 ///
 /// Quoting the datasheet: "Detection range is 2000 or 5000ppm"
-pub fn set_detection_range(device_number: u8, value: u16) -> Vec<u8> {
+pub fn set_detection_range(device_number: u8, value: u16) -> Packet {
     get_command_with_bytes34(
         Command::SetSensorDetectionRange,
         device_number,
@@ -110,7 +113,7 @@ pub fn set_detection_range(device_number: u8, value: u16) -> Vec<u8> {
 ///
 /// Quoting the datasheet: "Note：Zero point is 400ppm, please make sure the sensor has
 /// been worked under 400ppm for over 20 minutes"
-pub fn calibrate_zero_point(device_number: u8) -> Vec<u8> {
+pub fn calibrate_zero_point(device_number: u8) -> Packet {
     get_command_with_bytes34(Command::CalibrateZero, device_number, 0x00, 0x00)
 }
 
@@ -142,7 +145,7 @@ pub fn parse_payload(packet: &[u8]) -> Result<&[u8], MHZ19Error> {
 /// Get the CO2 gas concentration in ppm from a response packet.
 ///
 /// Will return an error if the packet is not a "read gas concentration packet"
-pub fn parse_gas_contentration_ppm(packet: &[u8]) -> Result<u32, MHZ19Error> {
+pub fn parse_gas_contentration_ppm(packet: &Packet) -> Result<u32, MHZ19Error> {
     let payload = parse_payload(packet)?;
     if payload[0] != Command::ReadGasConcentration.get_command_value() {
         Err(MHZ19Error::WrongPacketType(
@@ -166,6 +169,7 @@ pub enum MHZ19Error {
     WrongPacketType(u8, u8),
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for MHZ19Error {}
 
 impl fmt::Display for MHZ19Error {
@@ -196,62 +200,50 @@ impl fmt::Display for MHZ19Error {
 mod test {
     use super::*;
 
+    /// The command payload used to query the co2 cas concentration
+    /// from the device number 1 (the default device number)
+    ///
+    /// It is the same value as the result of
+    /// get_command_packet(Command::ReadGasConcentration, 1).
+    static READ_GAS_CONCENTRATION_COMMAND_ON_DEV1_PACKET: &'static [u8] =
+        &[0xFF, 0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00, 0x79];
+
+
     #[test]
     fn test_checksum() {
-        assert_eq!(
-            0x79,
-            checksum(&vec![0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00])
-        );
-        assert_eq!(
-            0xA0,
-            checksum(&vec![0x01, 0x88, 0x07, 0xD0, 0x00, 0x00, 0x00])
-        );
-        assert_eq!(
-            0xD1,
-            checksum(&vec![0x86, 0x02, 0x60, 0x47, 0x00, 0x00, 0x00])
-        );
+        assert_eq!(0x79, checksum(&[0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00]));
+        assert_eq!(0xA0, checksum(&[0x01, 0x88, 0x07, 0xD0, 0x00, 0x00, 0x00]));
+        assert_eq!(0xD1, checksum(&[0x86, 0x02, 0x60, 0x47, 0x00, 0x00, 0x00]));
     }
 
     #[test]
     fn test_get_payload() {
         assert_eq!(
-            Err(MHZ19Error::WrongPacketLength(0)),
-            parse_payload(&vec![])
-        );
-        assert_eq!(
-            Err(MHZ19Error::WrongPacketLength(1)),
-            parse_payload(&vec![12])
-        );
-        assert_eq!(
-            Err(MHZ19Error::WrongPacketLength(12)),
-            parse_payload(&vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
-        );
-        assert_eq!(
             Err(MHZ19Error::WrongStartByte(10)),
-            parse_payload(&vec![10, 2, 3, 4, 5, 6, 7, 8, 9])
+            parse_payload(&[10, 2, 3, 4, 5, 6, 7, 8, 9])
         );
         assert_eq!(
             Err(MHZ19Error::WrongChecksum(221, 9)),
-            parse_payload(&vec![0xFF, 2, 3, 4, 5, 6, 7, 8, 9])
+            parse_payload(&[0xFF, 2, 3, 4, 5, 6, 7, 8, 9])
         );
         assert_eq!(
             Err(MHZ19Error::WrongChecksum(0xD1, 0x10)),
-            parse_payload(&vec![0xFF, 0x86, 0x02, 0x60, 0x47, 0x00, 0x00, 0x00, 0x10])
+            parse_payload(&[0xFF, 0x86, 0x02, 0x60, 0x47, 0x00, 0x00, 0x00, 0x10])
         );
         assert_eq!(
-            Ok(vec![0x86, 0x02, 0x60, 0x47, 0x00, 0x00, 0x00].as_slice()),
-            parse_payload(&vec![0xFF, 0x86, 0x02, 0x60, 0x47, 0x00, 0x00, 0x00, 0xD1])
+            Ok(&[0x86, 0x02, 0x60, 0x47, 0x00, 0x00, 0x00][..]),
+            parse_payload(&[0xFF, 0x86, 0x02, 0x60, 0x47, 0x00, 0x00, 0x00, 0xD1])
         );
     }
 
     #[test]
     fn test_get_command_packet() {
         assert_eq!(
-            vec![0xFF, 0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00, 0x79],
+            [0xFF, 0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00, 0x79],
             get_command_with_bytes34(Command::ReadGasConcentration, 1, 0, 0)
         );
         assert_eq!(
-            Ok(vec![0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00].as_slice()),
+            Ok(&[0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
             parse_payload(&get_command_with_bytes34(
                 Command::ReadGasConcentration,
                 1,
@@ -260,11 +252,11 @@ mod test {
             ))
         );
         assert_eq!(
-            Vec::from(READ_GAS_CONCENTRATION_COMMAND_ON_DEV1_PACKET),
+            READ_GAS_CONCENTRATION_COMMAND_ON_DEV1_PACKET,
             get_command_with_bytes34(Command::ReadGasConcentration, 1, 0, 0)
         );
         assert_eq!(
-            Vec::from(READ_GAS_CONCENTRATION_COMMAND_ON_DEV1_PACKET),
+            READ_GAS_CONCENTRATION_COMMAND_ON_DEV1_PACKET,
             read_gas_concentration(1)
         );
 


### PR DESCRIPTION
Add support for working without `std`, that's important for usage in embedded. For example, I'm going to use it on stm32f103.

- All command generation methods now return `[u8; 9]` (which have `Packet` type alias) instead of `Vec<u8>`. There's no `Vec` in `std`. `heapless` [has `Vec` with fixed allocation](https://docs.rs/heapless/0.5.1/heapless/struct.Vec.html), but it isn't really needed here, as all packets have fixed size of 9 bytes.
- Added conditional compilation feature `std` which only enables implementation of `Error` for `MHZ19Error`:
   https://github.com/zenria/mh-z19-rs/blob/2522cafe8a975ee63b2032e48042c923ad3d7fa4/src/lib.rs#L172-L173
   I doubt if this impl is really needed. If you think it's not needed, it can be made always `no_std`. AFAIK, `no_std` libraries work in `std` environment without problems.
- As there's already changes in tests, I moved `READ_GAS_CONCENTRATION_COMMAND_ON_DEV1_PACKET` constant inside tests. It doesn't needed outside.

This change is backwards-incompatible, but I think it will not even break most code which just takes `Vec`s and pours them into serial port. Arrays have almost the same API as `Vec`s from the perspective of 'read-only' use.