### PR TITLE
Fixed a couple of typos and removed cargo.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 *.iml
 .idea
+/Cargo.lock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! [MH-Z19B Datasheet](https://www.winsen-sensor.com/d/files/infrared-gas-sensor/mh-z19b-co2-ver1_0.pdf)
 //!
-//! [MH-Z14 Dahasheet](https://www.winsen-sensor.com/d/files/infrared-gas-sensor/mh-z14a_co2-manual-v1_01.pdf)
+//! [MH-Z14 Datasheet](https://www.winsen-sensor.com/d/files/infrared-gas-sensor/mh-z14a_co2-manual-v1_01.pdf)
 //!
 //! This crates proposes two kinds of functions:
 //! - functions for parsing response read from the uart
@@ -145,7 +145,7 @@ pub fn parse_payload(packet: &[u8]) -> Result<&[u8], MHZ19Error> {
 /// Get the CO2 gas concentration in ppm from a response packet.
 ///
 /// Will return an error if the packet is not a "read gas concentration packet"
-pub fn parse_gas_contentration_ppm(packet: &[u8]) -> Result<u32, MHZ19Error> {
+pub fn parse_gas_concentration_ppm(packet: &[u8]) -> Result<u32, MHZ19Error> {
     let payload = parse_payload(packet)?;
     if payload[0] != Command::ReadGasConcentration.get_command_value() {
         Err(MHZ19Error::WrongPacketType(
@@ -155,6 +155,14 @@ pub fn parse_gas_contentration_ppm(packet: &[u8]) -> Result<u32, MHZ19Error> {
     } else {
         Ok(256 * (payload[1] as u32) + (payload[2] as u32))
     }
+}
+
+/// Get the CO2 gas concentration in ppm from a response packet.
+///
+/// Will return an error if the packet is not a "read gas concentration packet"
+#[deprecated = "Please use `parse_gas_concentration_ppm` instead"]
+pub fn parse_gas_contentration_ppm(packet: &[u8]) -> Result<u32, MHZ19Error> {
+    parse_gas_concentration_ppm(packet)
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
Hi @zenria! First of all, let me thank you for the library you've made, it really saved me from implementing mh-z19 UART protocol :)

While working with the code, my spellcheck plugin found a typo in the `parse_gas_contentration_ppm` function, so I've renamed it into `parse_gas_concentration_ppm`, and made the former a "deprecated" function (which internally calls the latter) in order to avoid a major version change.

I've also excluded the cargo lock file, since it's a library (not an executable) and it doesn't make a lot of sense to store it in the repository (it is also advised by the cargo book: https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html).